### PR TITLE
Fixed treemap bug

### DIFF
--- a/web/packages/client/typescript/components/ApexChart.tsx
+++ b/web/packages/client/typescript/components/ApexChart.tsx
@@ -188,7 +188,7 @@ export class ApexChart extends Component<ComponentProps<ApexChartProps>, any> {
 
     @bind
     prepareSeries(type, series) {
-        if (type !== "pie" && type !== "donut" && type !== "radialBar" && type !== "rangeBar" && type !== "polarArea"){
+        if (type !== "pie" && type !== "donut" && type !== "radialBar" && type !== "rangeBar" && type !== "polarArea" && type !== "treemap"){
             for (let s of series) {
                 if (typeof s.data === 'undefined' || s.data === null || typeof s.data === 'string' || typeof s.data === 'number' || typeof s.data === 'bigint' || typeof s.data === 'boolean' || typeof s.data === 'symbol' || typeof s.data === 'function') {
                     s.data = [];


### PR DESCRIPTION
This is just a minor update to allow using the treemap visual

In the current version (v1.0.3) the treemap visual doesn't seem to work, and we are instead seeing a single box being drawn.

I've tried using the example dataset from the [Apex website](https://apexcharts.com/javascript-chart-demos/treemap-charts/basic/) as an example, below is what we are getting.
![before](https://user-images.githubusercontent.com/10542389/145349696-bc627895-eace-4df0-994c-a38352834860.png)

After applying the change to the code, the same dataset now looks correct.
![image](https://user-images.githubusercontent.com/10542389/145349550-5e394c6b-0cce-4119-aae5-0b86cb2a3e20.png)

Many thanks
-Gary